### PR TITLE
Add GitHub Actions CI workflow and README status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint --if-present
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test --if-present
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build --if-present

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # TimeTravellerEngineer
+
+[![CI](https://github.com/<OWNER>/TimeTravellerEngineer/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/<OWNER>/TimeTravellerEngineer/actions/workflows/ci.yml)


### PR DESCRIPTION
### Motivation
- Introduce a standard CI pipeline to run lint, tests, and build on pushes and pull requests to improve code quality and catch regressions early.
- Ensure runs are limited to the `main` branch for pushes and that outdated workflow runs are cancelled to reduce noise and wasted resources.
- Provide a visible CI status badge in the `README` to indicate repository health and encourage branch protection configuration in GitHub settings.

### Description
- Add a new workflow at `./github/workflows/ci.yml` that triggers on `push` (to `main`) and `pull_request` and uses `concurrency` to cancel in-progress outdated runs.
- Define ordered jobs `setup` -> `lint` -> `test` -> `build` where each job checks out the repo, sets up Node.js 20 using `actions/setup-node@v4` with `cache: npm`, and runs the requested npm commands with `--if-present` where appropriate.
- Run dependency installation with `npm ci` in `lint`, `test`, and `build` jobs and run `npm run lint --if-present`, `npm test --if-present`, and `npm run build --if-present` respectively.
- Add a CI badge to `README.md` pointing to the new workflow (placeholder `<OWNER>` in the badge URL) and commit the changes.

### Testing
- Inspected the new workflow file with `cat -n .github/workflows/ci.yml` and verified contents, which succeeded.
- Verified `README.md` update with `cat -n README.md`, which succeeded.
- Created a local commit with `git add .github/workflows/ci.yml README.md && git commit -m "Add GitHub Actions CI workflow and README badge"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996a2aae9c48322a92388d6abb60a65)