### PR TITLE
Add production GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build --if-present
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # TimeTravellerEngineer
+
+## Deployment
+
+This repository deploys to **GitHub Pages** through `.github/workflows/deploy.yml` after CI succeeds on `main`.
+
+### Deployment flow
+
+1. `CI` completes successfully for the `main` branch.
+2. The deploy workflow checks out the exact commit tested in CI.
+3. The project is rebuilt with:
+   - `npm ci`
+   - `npm run build --if-present`
+4. The generated `dist/` directory is uploaded and deployed with the official GitHub Pages actions.
+5. Deployment targets the `production` GitHub Environment.
+
+> Configure required reviewers and any deployment secrets under:
+> **Settings → Environments → production**.
+
+### Rollback
+
+1. Open **Actions → Deploy**.
+2. Select a previous successful run for a known-good commit.
+3. Use **Re-run jobs** to redeploy that artifact/commit to production.
+
+If you need to roll back to a specific commit not already deployed recently, trigger CI for that commit (for example by reverting/cherry-picking on `main`) and let Deploy run again after CI succeeds.
+
+### Redeploy current `main`
+
+1. Open the latest successful **CI** run on `main`.
+2. Re-run CI jobs.
+3. After CI completes successfully, the Deploy workflow triggers automatically and publishes the rebuilt `dist/` output.


### PR DESCRIPTION
### Motivation

- Provide an automated, gated deployment path that publishes the built site only after a successful CI run on `main` to reduce risk of untested releases.
- Use GitHub Environments so production deployments can require reviewers and secrets, and record deployment metadata.

### Description

- Add a new workflow `.github/workflows/deploy.yml` that triggers on `workflow_run` for the `CI` workflow with `types: [completed]` and only runs when the CI conclusion is `success` and the head branch is `main`.
- Rebuild the project during deployment using `npm ci` and `npm run build --if-present`, then upload the `dist/` directory and deploy to GitHub Pages using the official Pages actions (`actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`).
- Configure workflow permissions (`contents: read`, `pages: write`, `id-token: write`), concurrency group `pages-deploy`, and target the `production` GitHub Environment with the deployment output URL.
- Update `README.md` with a `Deployment` section that documents the deployment flow, required environment setup (reviewers/secrets), rollback instructions, and redeploy steps.

### Testing

- Printed and inspected the workflow and README with `cat .github/workflows/deploy.yml` and `nl -ba README.md` to verify content and structure, and a small Python snippet was run to fix an interpolation expression; these commands completed successfully.
- Verified the workflow file displays the expected Node setup, build steps, artifact upload, and deploy actions by reviewing the file contents; the inspection succeeded.
- Confirmed the README contains the new `Deployment` section describing flow, rollback, and redeploy steps; the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ad7733ac8322aa3e31306914f9c7)