### PR TITLE
docs: add deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ export default defineConfig([
   },
 ])
 ```
+## Deploy
+[code-mind-one.vercel.app](https://code-mind-one.vercel.app)


### PR DESCRIPTION
Adds production deploy link to README.

Closes #31.