### PR TITLE
chore: add PR templates (#34)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,12 @@
+## Linked issue
+Closes #<issue_number>
+
+## Chore / CI / Tooling
+- What changed and why.
+
+## Impact
+- Does it affect dev workflow / build / deploy?
+
+## Checklist
+- [ ] CI is green.
+- [ ] No breaking changes for teammates.

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,9 @@
+## Linked issue
+Closes #<issue_number>
+
+## Docs change
+- What was updated and why.
+
+## Checklist
+- [ ] Links work.
+- [ ] Formatting looks good.

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+## Linked issue
+Closes #<issue_number>
+
+## Feature summary
+- What user value is delivered.
+
+## UI / UX
+- Design link (Figma):
+- Screenshots / video:
+
+## How to test
+1. Steps for reviewer:
+2. Edge cases:
+
+## Personal Score (if this is my personal feature)
+- Diary entry / video link:
+
+## Checklist
+- [ ] CI is green.
+- [ ] Issue card moved to In review.

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -1,0 +1,19 @@
+## Linked issue
+Closes #<issue_number>
+
+## Bug
+- What was broken.
+
+## Reproduction
+1. Step 1
+2. Step 2
+
+## Fix
+- What changed.
+
+## How to test
+- Steps / tests added:
+
+## Checklist
+- [ ] CI is green.
+- [ ] Regression risk checked.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Linked issue
+Closes #<issue_number>
+
+## Summary
+- What was changed and why.
+
+## Type
+- [ ] Feature
+- [ ] Fix
+- [ ] Docs
+- [ ] Refactor
+- [ ] Chore / CI
+
+## Screenshots (if UI)
+- Before:
+- After:
+
+## How to test
+1. `npm ci`
+2. `npm run lint`
+3. `npm run test` (or N/A)
+4. `npm run build`
+5. Manual checks:
+
+## Personal Score (if this is my personal feature)
+- Diary entry / video link:
+
+## Checklist (RS Tandem)
+- [ ] PR has description + screenshots (if UI) + issue link.
+- [ ] Branch name is semantic (feat/... fix/... docs/... chore/...).
+- [ ] Conventional commits are used (feat:/fix:/chore:).
+- [ ] CI checks are green.
+- [ ] No trash files committed (.DS_Store, node_modules, etc.).
+- [ ] Issue card moved in Project board.
+- [ ] Deploy link exists in README (for deliverable milestones).


### PR DESCRIPTION
Adds default PR template and additional templates (feature/fix/docs/chore) for RS Tandem workflow.

Closes #34.